### PR TITLE
ggml_alibi: fix incorrect src1 size

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -6099,7 +6099,7 @@ struct ggml_tensor * ggml_alibi(
     //struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
     struct ggml_tensor * result = ggml_view_tensor(ctx, a);
 
-    struct ggml_tensor * b = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 3);
+    struct ggml_tensor * b = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 2);
     ((int32_t *) b->data)[0] = n_past;
     ((int32_t *) b->data)[1] = n_head;
 


### PR DESCRIPTION
this becomes 3 again to pass an extra param through after the changes in the ggml MPT PR lands but for now this stops tripping an assert in `ggml_compute_forward_alibi_f32` so that debug builds don't fail immediately.